### PR TITLE
Fix for jira-python module rename

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ python:
 install:
   - pip install pep8
 script:
-  - pep8 -v jiracli
+  - pep8 --ignore=E731 -v jiracli

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# Docker Infrastructure (see http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/ )
+sudo: false
+
 language: python
 python:
   - "2.7"

--- a/README.rst
+++ b/README.rst
@@ -3,11 +3,11 @@ Jira command line interface
 .. image:: https://travis-ci.org/toabctl/jiracli.svg
     :target: https://travis-ci.org/toabctl/jiracli
 
-`jiracli` is a simple command line interface based on the `jira-python` module. The module uses the REST API to communicate with the Jira instance.
+`jiracli` is a simple command line interface based on the `jira` module. The module uses the REST API to communicate with the Jira instance.
 
 Installation
 ============
-`python2.7` and `jira-python` from https://pypi.python.org/pypi/jira-python/ is needed.
+`python2.7` and `jira` from https://pypi.python.org/pypi/jira/ is needed.
 
  * You can install `jiracli` with pip in a virtual environment::
 

--- a/jiracli/__init__.py
+++ b/jiracli/__init__.py
@@ -202,7 +202,7 @@ def issue_format(issue, show_desc=False, show_comments=False,
         if hasattr(issue.fields, 'comment'):
             fields['comments'] = "%s\n%s" % (
                 len(issue.fields.comment.comments),
-                "\n\n".join(map(lambda x: "%s\n%s" % (colorfunc("%s, %s" % (dtstr2dt(x.updated), x.updateAuthor.name), None, attrs=['reverse']), x.body),  issue.fields.comment.comments)))  # noqa
+                "\n\n".join(map(lambda x: "%s\n%s" % (colorfunc("%s, %s" % (dtstr2dt(x.updated), x.updateAuthor.name), None, attrs=['reverse']), x.body), issue.fields.comment.comments)))  # noqa
         else:
             fields['comments'] = "0"
     else:

--- a/jiracli/__init__.py
+++ b/jiracli/__init__.py
@@ -29,7 +29,7 @@ import subprocess
 import tabulate
 from collections import OrderedDict
 from termcolor import colored as colorfunc
-from jira.client import JIRA
+from jira import JIRA
 import tempfile
 
 # log object
@@ -75,11 +75,12 @@ def config_credentials_get():
     return user, password, url
 
 
-def sprint(jira, project):
-    issues = jira.search_issues('project = "%s" AND sprint IN openSprints()' %
-                                project)
-    width, height = [int(v) for v in
-                     subprocess.check_output(["stty", "size"]).strip().split()]
+def sprint(jira_obj, project):
+    issues = jira_obj.search_issues(
+        'project = "%s" AND sprint IN openSprints()' % project)
+    width, height = [
+        int(v) for v in
+        subprocess.check_output(["stty", "size"]).strip().split()]
 
     content = []
     sizes = [0, 0, 0]
@@ -211,7 +212,7 @@ def issue_format(issue, show_desc=False, show_comments=False,
             fields['comments'] = "%s" % (len(issue.fields.comment.comments))
 
     if show_trans:
-        transitions = jira.transitions(issue)
+        transitions = jira_obj.transitions(issue)
         fields['trans'] = ", ".join(map(
             lambda x: x['name'] + "(" + x['id'] + ")", transitions))
 
@@ -248,11 +249,11 @@ def issue_list_print(issue_list, show_desc, show_comments,
 def issue_search_result_print(searchstring_list):
     """print issues for the given search string(s)"""
     for searchstr in searchstring_list:
-        issues = jira.search_issues(searchstr)
+        issues = jira_obj.search_issues(searchstr)
         # FIXME: debug problem why comments are not available
-        # if I use jira.search_issues()
+        # if I use jira_obj.search_issues()
         # get issues again.
-        issues = [jira.issue(i.key) for i in issues]
+        issues = [jira_obj.issue(i.key) for i in issues]
         issue_list_print(issues, args['issue_desc'], args['issue_comments'],
                          args['issue_trans'], args['issue_oneline'])
 
@@ -399,7 +400,7 @@ def main():
     args = parse_args()
     setup_logging(log, args['debug'])
     conf = config_get()
-    jira = jira_obj_get(conf)
+    jira_obj = jira_obj_get(conf)
 
     # use colorful output?
     if args['no_color']:
@@ -409,45 +410,45 @@ def main():
     if args['issue_link_types_list']:
         # print("%s%s%s" % ("name".ljust(30), "inward".ljust(25),
         # "outward".ljust(25)))
-        for i in jira.issue_link_types():
+        for i in jira_obj.issue_link_types():
             print("%s%s%s" % (i.name.ljust(30),
                               i.inward.ljust(25), i.outward.ljust(25)))
         sys.exit(0)
 
     # print project list and exit
     if args['project_list']:
-        for p in jira.projects():
+        for p in jira_obj.projects():
             print(p.id.ljust(10), p.key.ljust(10), p.name.ljust(30))
         sys.exit(0)
 
     # print issue types
     if args['issue_type_list']:
-        for it in jira.issue_types():
+        for it in jira_obj.issue_types():
             print(it.id.ljust(10), it.name.ljust(30), it.description.ljust(10))
         sys.exit(0)
 
     # print project components
     if args['project_list_components']:
         for pro in args['project_list_components']:
-            components = jira.project_components(pro)
+            components = jira_obj.project_components(pro)
             [print(c.id.ljust(10), c.name) for c in components]
         sys.exit(0)
 
     # print favourite filters for current user
     if args['filter_list_fav']:
-        filter_list_print(jira.favourite_filters())
+        filter_list_print(jira_obj.favourite_filters())
         sys.exit(0)
 
     # add a label to an issue
     if args['issue_label_add']:
-        issue = jira.issue(args['issue_label_add'][0])
+        issue = jira_obj.issue(args['issue_label_add'][0])
         issue.fields.labels.append(args['issue_label_add'][1])
         issue.update(fields={"labels": issue.fields.labels})
         sys.exit(0)
 
     # remove label from an issue
     if args['issue_label_remove']:
-        issue = jira.issue(args['issue_label_remove'][0])
+        issue = jira_obj.issue(args['issue_label_remove'][0])
         labels_new = filter(lambda x: x.lower() !=
                             args['issue_label_remove'][1].lower(),
                             issue.fields.labels)
@@ -456,7 +457,7 @@ def main():
 
     # add component to an issue
     if args['issue_component_add']:
-        issue = jira.issue(args['issue_component_add'][0])
+        issue = jira_obj.issue(args['issue_component_add'][0])
         comp = {'name': args['issue_component_add'][1]}
         components_available = [{'name': c.name}
                                 for c in issue.fields.components]
@@ -466,7 +467,7 @@ def main():
 
     # remove component from an issue
     if args['issue_component_remove']:
-        issue = jira.issue(args['issue_component_remove'][0])
+        issue = jira_obj.issue(args['issue_component_remove'][0])
         components_new = [
             {'name': x.name}
             for x in filter(lambda x: x.name.lower() !=
@@ -477,7 +478,7 @@ def main():
 
     # add a fixVersion to an issue
     if args['issue_fix_version_add']:
-        issue = jira.issue(args['issue_fix_version_add'][0])
+        issue = jira_obj.issue(args['issue_fix_version_add'][0])
         fix_version_new = {'name': args['issue_fix_version_add'][1]}
         fix_versions_available = [
             {'name': c.name} for c in issue.fields.fixVersions]
@@ -487,7 +488,7 @@ def main():
 
     # remove fixVersion from an issue
     if args['issue_fix_version_remove']:
-        issue = jira.issue(args['issue_fix_version_remove'][0])
+        issue = jira_obj.issue(args['issue_fix_version_remove'][0])
         fix_versions_new = [
             {'name': x.name} for x in filter(
                 lambda x: x.name.lower() !=
@@ -499,37 +500,37 @@ def main():
     # move issue(s) to Open state
     if args['issue_trans_open']:
         for i in args['issue_trans_open']:
-            jira.transition_issue(i, 3)
+            jira_obj.transition_issue(i, 3)
             log.debug("moved to open : issue '%s'", i)
         sys.exit(0)
 
     # move issue(s) to Start Progress state
     if args['issue_trans_start']:
         for i in args['issue_trans_start']:
-            jira.transition_issue(i, 4)
+            jira_obj.transition_issue(i, 4)
             log.debug("moved to progress : issue '%s'", i)
         sys.exit(0)
 
     # move issue(s) to Start Resolved state
     if args['issue_trans_resolve']:
         for i in args['issue_trans_resolve']:
-            # jira.transition_issue(i, 5, assignee={'name': conf['user']},
+            # jira_obj.transition_issue(i, 5, assignee={'name': conf['user']},
             # resolution={'id': '1'})
-            jira.transition_issue(i, 5, resolution={'id': '1'})
+            jira_obj.transition_issue(i, 5, resolution={'id': '1'})
             log.debug("moved to progress : issue '%s'", i)
         sys.exit(0)
 
     # add watch to issue(s)
     if args['issue_watch_add']:
         for i in args['issue_watch_add']:
-            jira.add_watcher(i, conf['user'])
+            jira_obj.add_watcher(i, conf['user'])
             log.debug("added watch for issue '%s'", i)
         sys.exit(0)
 
     # remove watch to issue(s)
     if args['issue_watch_remove']:
         for i in args['issue_watch_remove']:
-            jira.remove_watcher(i, conf['user'])
+            jira_obj.remove_watcher(i, conf['user'])
             log.debug("removed watch for issue '%s'", i)
         sys.exit(0)
 
@@ -541,15 +542,15 @@ def main():
             comment = editor_get_text(
                 "-- your comment for issue %s" %
                 (args['issue_comment_add'][0]))
-        issue = jira.issue(args['issue_comment_add'][0])
-        jira.add_comment(issue, comment)
+        issue = jira_obj.issue(args['issue_comment_add'][0])
+        jira_obj.add_comment(issue, comment)
         log.debug("comment added to issue '%s'", args['issue_comment_add'][0])
         sys.exit(0)
 
     # print issue by filter search
     if args['issue_search_by_filter']:
         searchstring_list = [
-            jira.filter(f).jql for f in args['issue_search_by_filter']]
+            jira_obj.filter(f).jql for f in args['issue_search_by_filter']]
         issue_search_result_print(searchstring_list)
         sys.exit(0)
 
@@ -574,7 +575,7 @@ def main():
         if args['issue_parent']:
             issue_dict['parent'] = {'id': args['issue_parent']}
 
-        new_issue = jira.create_issue(fields=issue_dict)
+        new_issue = jira_obj.create_issue(fields=issue_dict)
         issue_list_print([new_issue], True, True, False)
         sys.exit(0)
 
@@ -611,7 +612,7 @@ def main():
                     issue_dict['summary'] = n
 
                 # create and print the new issue
-                new_issue = jira.create_issue(fields=issue_dict)
+                new_issue = jira_obj.create_issue(fields=issue_dict)
                 issue_list_print([new_issue], True, True, False)
                 if not is_subtask:
                     parent_id = new_issue.key
@@ -624,12 +625,12 @@ def main():
         sys.exit(0)
 
     if args['sprint']:
-        sprint(jira, args['sprint'][0])
+        sprint(jira_obj, args['sprint'][0])
         sys.exit(0)
 
     # print issue(s) and exit
     if args['issue']:
-        issues = [jira.issue(i) for i in args['issue']]
+        issues = [jira_obj.issue(i) for i in args['issue']]
         issue_list_print(
             issues, args['issue_desc'], args['issue_comments'],
             args['issue_trans'], args['issue_oneline'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # pbr should be first
 pbr>=0.6
-jira-python>=0.13
+jira>=0.47
 tabulate
 termcolor


### PR DESCRIPTION
The python modules python-jira was renamed to jira.
Require the new module and also fix some possible naming
conflicts due to the rename.