### PR TITLE
check that priority attr exists or use 'n/a'

### DIFF
--- a/jiracli/__init__.py
+++ b/jiracli/__init__.py
@@ -151,12 +151,17 @@ def issue_status_color(status):
 
 def issue_header(issue):
     """get a single line string for an issue"""
+    if hasattr(issue.fields, "priority"):
+        priority = "%s" % issue.fields.priority.name
+    else:
+        priority = "n/a"
+
     return "%s (%s)" % (colorfunc("%s, %s: %s" % (issue.key,
                                                   issue.fields.issuetype.name,
                                                   issue.fields.summary),
                                   None, attrs=['bold', 'underline']),
                         colorfunc("%s, %s" % (issue.fields.status.name,
-                                              issue.fields.priority.name),
+                                              priority),
                                   issue_status_color(issue.fields.status.name),
                                   attrs=['bold']))
 


### PR DESCRIPTION
For whatever reason, you can configure JIRA to allow issues to not have priorities for some issue types it appears- seems like maybe Epics by default don't have a priority.

I was receiving this prior to this change-
```
Traceback (most recent call last):
  File "/opt/twitter/bin/jiracli", line 10, in <module>
    sys.exit(main())
  File "/opt/twitter/lib/python2.7/site-packages/jiracli/__init__.py", line 631, in main
    issue_search_result_print(jira_obj, args, args['issue_search'])
  File "/opt/twitter/lib/python2.7/site-packages/jiracli/__init__.py", line 264, in issue_search_result_print
    args['issue_oneline'])
  File "/opt/twitter/lib/python2.7/site-packages/jiracli/__init__.py", line 242, in issue_list_print
    print(issue_header(issue))
  File "/opt/twitter/lib/python2.7/site-packages/jiracli/__init__.py", line 154, in issue_header
    if hasattr(issue.fields.priority, "name"):
AttributeError: type object 'PropertyHolder' has no attribute 'priority'
```

After this change I no longer receive this error and it lists the offending issue properly with the expected status.

`FOO-1234, Epic: Do some really really important stuff (Resolved, n/a)`