### PR TITLE
Fix issue_list_print() TypeError when using --issues-create

### DIFF
--- a/jiracli/__init__.py
+++ b/jiracli/__init__.py
@@ -620,7 +620,7 @@ def main():
 
                 # create and print the new issue
                 new_issue = jira_obj.create_issue(fields=issue_dict)
-                issue_list_print(jira_obj, [new_issue], True, True, False)
+                issue_list_print(jira_obj, [new_issue], True, True, False, False)
                 if not is_subtask:
                     parent_id = new_issue.key
 


### PR DESCRIPTION
'TypeError: issue_list_print() takes exactly 6 arguments (5 given)' when creating an issue from a file using --issues-create