### PR TITLE
Fix editor_get_text function

### DIFF
--- a/jiracli/__init__.py
+++ b/jiracli/__init__.py
@@ -63,9 +63,10 @@ def editor_get_text(text_template):
     tf.flush()
     editor = os.environ.setdefault("EDITOR", "vim")
     os.system("%s %s" % (editor, tf.name))
-    tf.seek(0)
-    return "\n".join([line for line in tf.read().split('\n')
-                      if not line.startswith("--")])
+    rdr = open(tf.name, 'r')
+    rdr.seek(0)
+    return "".join([line for line in rdr.readlines()
+                    if not line.startswith("--")])
 
 
 def config_credentials_get():


### PR DESCRIPTION
On my OS X install, this function was never able to see the content inserted by my editor (vim). I'm unsure of why, specifically, but opening another File object against the path (after the editor exits) seems to work around the issue just fine.
