### PR TITLE
Add --issue-assign flag; auto-assign when starting an issue

### DIFF
--- a/jiracli/__init__.py
+++ b/jiracli/__init__.py
@@ -389,6 +389,10 @@ def parse_args():
     group_issue.add_argument("--issue-watch-remove", nargs='+',
                              metavar='issue',
                              help='Remove watch from the given issue(s)')
+    # assignee
+    group_issue.add_argument("--issue-assign", nargs=2,
+                             metavar=('issue', 'assignee'),
+                             help='Assign the issue to the specified user')
     # fix versions
     group_issue.add_argument("--issue-fix-version-add", nargs='+',
                              metavar='issue',
@@ -515,6 +519,7 @@ def main():
     # move issue(s) to Start Progress state
     if args['issue_trans_start']:
         for i in args['issue_trans_start']:
+            jira_obj.assign_issue(i, conf['user'])
             jira_obj.transition_issue(i, 4)
             log.debug("moved to progress : issue '%s'", i)
         sys.exit(0)
@@ -541,6 +546,11 @@ def main():
             jira_obj.remove_watcher(i, conf['user'])
             log.debug("removed watch for issue '%s'", i)
         sys.exit(0)
+
+    # assign the issue
+    if args['issue_assign']:
+        issue, assignee = args['issue_assign']
+        jira_obj.assign_issue(issue, assignee)
 
     # add comment to issue
     if args['issue_comment_add']:


### PR DESCRIPTION
This commit adds an `--issue-assign` flag, allowing a user to do the following:

```
jiracli --issue-assign EXAMPLE-1234 jdoe
```

It also adds functionality to assign a ticket to the current user upon starting the issue.
