### PR TITLE
Use six for py3 compatible input usage (closes #26)

### DIFF
--- a/jiracli/__init__.py
+++ b/jiracli/__init__.py
@@ -23,6 +23,7 @@ import six
 import sys
 import argparse
 from six.moves import configparser as ConfigParser
+from six.moves import input
 import logging
 import getpass
 import datetime
@@ -70,9 +71,9 @@ def editor_get_text(text_template):
 
 def config_credentials_get():
     # get username, password and url
-    user = raw_input("username:")
+    user = input("username:")
     password = getpass.getpass()
-    url = raw_input("url:")
+    url = input("url:")
     return user, password, url
 
 


### PR DESCRIPTION
raw_input() was renamed to input() in python3. Use the six module
to solve this.