### PR TITLE
editor_get_text: update NamedTemporaryfile mode

### DIFF
--- a/jiracli/__init__.py
+++ b/jiracli/__init__.py
@@ -58,7 +58,7 @@ def setup_logging(logger, debug):
 
 def editor_get_text(text_template):
     """get text from an editor via a tempfile"""
-    tf = tempfile.NamedTemporaryFile()
+    tf = tempfile.NamedTemporaryFile(mode="w+t", delete=False)
     tf.write("-- lines starting with '--' will be ignored\n")
     tf.write(text_template)
     tf.flush()


### PR DESCRIPTION
With python3 the default behaviour of NamedTemporaryfile() has changed,
such that now when jiracli would need to open a text editor and take input
from the temporary file, you would experience a crash like the following:

    Traceback (most recent call last):
      File "/usr/local/bin/jiracli", line 11, in <module>
        sys.exit(main())
      File "/usr/local/lib/python3.4/dist-packages/jiracli/__init__.py", line 568, in main
        desc = editor_get_text("-- describe the issue here")
      File "/usr/local/lib/python3.4/dist-packages/jiracli/__init__.py", line 61, in editor_get_text
        tf.write("-- lines starting with '--' will be ignored\n")
      File "/usr/lib/python3.4/tempfile.py", line 538, in func_wrapper
        return func(*args, **kwargs)
    TypeError: 'str' does not support the buffer interface

Switching it to have an explicit 'mode="w"' parameter changed the error
slightly:

    Traceback (most recent call last):
      File "/usr/local/bin/jiracli", line 11, in <module>
        sys.exit(main())
      File "/usr/local/lib/python3.4/dist-packages/jiracli/__init__.py", line 568, in main
        desc = editor_get_text("-- describe the issue here")
      File "/usr/local/lib/python3.4/dist-packages/jiracli/__init__.py", line 67, in editor_get_text
        return "\n".join([line for line in tf.read().split('\n')
      File "/usr/lib/python3.4/tempfile.py", line 538, in func_wrapper
        return func(*args, **kwargs)
    io.UnsupportedOperation: not readable

So we explicitly set the temporary file as 'text' in addition to being
writeable.

Signed-off-by: Joe MacDonald <joe_macdonald@mentor.com>