### PR TITLE
setup.cfg: Remove BSD license classifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,6 @@ classifier =
     Development Status :: 4 - Beta
     Environment :: Console
     License :: OSI Approved :: GNU General Public License v3 (GPLv3)
-    License :: OSI Approved :: BSD License
     Programming Language :: Python
     Topic :: Software Development :: Bug Tracking
     Topic :: Utilities


### PR DESCRIPTION
File `LICENSE` only mentions GPL